### PR TITLE
Handle external file path references for windows properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var converter = require('./lib/convert'),
     async = require('async'),
+    process = require('process'),
     ramlParser = require('raml-parser'),
     importer,
     _ = require('lodash'),

--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ importer = {
             }
             return {
                 result: true,
-                data: rootFiles[0].data
+                data: rootFiles[0].fileName
             };
         }
         else {
@@ -238,9 +238,11 @@ importer = {
     },
 
     getMetaData: function(input, callback) {
-        var validation = importer.validate(input);
-        converter.getMetaData(validation.data, callback);
-}
+        var validation = importer.validate(input),
+            allFiles = (input.type === 'folder' ? _.map(input.data, 'fileName') : []);
+
+        converter.getMetaData({ type: input.type, data: validation.data, allFiles }, callback);
+    }
 };
 
 module.exports = importer;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
+const { pathToFileURL } = require('url');
+
 var converter = require('./lib/convert'),
     async = require('async'),
-    process = require('process'),
+    path = require('path'),
     ramlParser = require('raml-parser'),
     importer,
     _ = require('lodash'),
@@ -137,8 +139,7 @@ importer = {
                 var reader = new ramlParser.FileReader(function (filePath) {
                         return new Promise(function (resolve, reject) {
                             var targetFilePath = decodeURIComponent(filePath);
-
-                            if (process.platform == 'win32' || process.platform == 'win64') {
+                            if (path.sep === '\\') {
                                 // Parser returns windows drive letter in lowercase
                                 // Ignore case sensitivity, as windows file sytem is case-insensitive
                                 allFiles = _.map(allFiles, _.toLower);

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -21,7 +21,7 @@ var converter = {
                 return new Promise(function (resolve, reject) {
                     var targetFilePath = decodeURIComponent(filePath);
 
-                    if (process.platform == 'win32' || process.platform == 'win64') {
+                    if (path.sep === '\\') {
                         // Parser returns windows drive letter in lowercase
                         // Ignore case sensitivity, as windows file sytem is case-insensitive
                         allFiles = _.map(allFiles, _.toLower);

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -5,6 +5,7 @@ var validator = require('postman_validator');
 var raml = require('raml-parser');
 var _ = require('lodash').noConflict();
 var async = require('async');
+var ramlParser = require('raml-parser');
 
 const DEFAULT_NAME = 'Postman Collection (From RAML0.8)';
 
@@ -14,8 +15,32 @@ var converter = {
     currentFolder: {},
     env: {},
 
-    getMetaData: function(ramlString, callback) {
-        raml.load(ramlString).then(function(data) {
+    getMetaData: function(input, callback) {
+        var allFiles = input.allFiles,
+            reader = new ramlParser.FileReader(function (filePath) {
+                return new Promise(function (resolve, reject) {
+                    var targetFilePath = decodeURIComponent(filePath);
+
+                    if (process.platform == 'win32' || process.platform == 'win64') {
+                        // Parser returns windows drive letter in lowercase
+                        // Ignore case sensitivity, as windows file sytem is case-insensitive
+                        allFiles = _.map(allFiles, _.toLower);
+                        targetFilePath = targetFilePath.toLowerCase();
+
+                        // As parser simply returns appended path, transform file path to windows file path system
+                        targetFilePath = targetFilePath.replace(/\//g, '\\');
+                    }
+                    if (_.includes(allFiles, targetFilePath) && fs.existsSync(targetFilePath)) {
+                        resolve(fs.readFileSync(targetFilePath).toString());
+                    }
+                    else {
+                        reject(new Error('Unable to find file ' + targetFilePath + ' in uploaded data'));
+                    }
+                });
+            });
+
+        
+        (input.type === 'folder' ? raml.loadFile : raml.load)(input.data, { reader: reader }).then(function(data) {
             try {
                 const collectionName = data.title ? data.title : DEFAULT_NAME,
                     environemntName = collectionName + '\'s Environment'

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -5,7 +5,6 @@ var validator = require('postman_validator');
 var raml = require('raml-parser');
 var _ = require('lodash').noConflict();
 var async = require('async');
-var ramlParser = require('raml-parser');
 
 const DEFAULT_NAME = 'Postman Collection (From RAML0.8)';
 
@@ -15,32 +14,8 @@ var converter = {
     currentFolder: {},
     env: {},
 
-    getMetaData: function(input, callback) {
-        var allFiles = input.allFiles,
-            reader = new ramlParser.FileReader(function (filePath) {
-                return new Promise(function (resolve, reject) {
-                    var targetFilePath = decodeURIComponent(filePath);
-
-                    if (path.sep === '\\') {
-                        // Parser returns windows drive letter in lowercase
-                        // Ignore case sensitivity, as windows file sytem is case-insensitive
-                        allFiles = _.map(allFiles, _.toLower);
-                        targetFilePath = targetFilePath.toLowerCase();
-
-                        // As parser simply returns appended path, transform file path to windows file path system
-                        targetFilePath = targetFilePath.replace(/\//g, '\\');
-                    }
-                    if (_.includes(allFiles, targetFilePath) && fs.existsSync(targetFilePath)) {
-                        resolve(fs.readFileSync(targetFilePath).toString());
-                    }
-                    else {
-                        reject(new Error('Unable to find file ' + targetFilePath + ' in uploaded data'));
-                    }
-                });
-            });
-
-        
-        (input.type === 'folder' ? raml.loadFile : raml.load)(input.data, { reader: reader }).then(function(data) {
+    getMetaData: function(ramlString, callback) {
+        raml.load(ramlString).then(function(data) {
             try {
                 const collectionName = data.title ? data.title : DEFAULT_NAME,
                     environemntName = collectionName + '\'s Environment'


### PR DESCRIPTION
Used `//` as path separator for windows instead `/`.