### PR TITLE
Fix import folder flow where getMetaData() was failing. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ importer = {
     getMetaData: function(input, callback) {
         var validation = importer.validate(input);
         converter.getMetaData(validation.data, callback);
-}
+    }
 };
 
 module.exports = importer;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -15,29 +15,29 @@ var converter = {
     env: {},
 
     getMetaData: function(ramlString, callback) {
-        raml.load(ramlString).then(function(data) {
-            try {
-                const collectionName = data.title ? data.title : DEFAULT_NAME,
-                    environemntName = collectionName + '\'s Environment'
 
-                return callback(null, {
-                    result: true,
-                    name: collectionName,
-                    output: [{
-                        type: 'collection',
-                        name: data.title || 'Postman Collection (From RAML0.8)'
-                    },
-                    {
-                        type: 'environment',
-                        name: environemntName
-                    }]
-                });
+        let titleName = DEFAULT_NAME;
+
+        // find title name from root file instead loading entire spec consisting of external files
+        _.forEach(ramlString.split('\n'), (element) => {
+            element = element.trim();
+            if (element.startsWith('title:')) {
+                titleName = element.slice(6).trim();
+                return false;
             }
-            catch (e) {
-                return callback(e);
-            }
-        }, function(err) {
-            return callback(err);
+        });
+
+        return callback(null, {
+            result: true,
+            name: titleName,
+            output: [{
+                type: 'collection',
+                name: titleName || 'Postman Collection (From RAML0.8)'
+            },
+            {
+                type: 'environment',
+                name: titleName + '\'s Environment'
+            }]
         });
     },
 


### PR DESCRIPTION
This PR fixes breaking `getMetaData()` function for input type of folder.