### PR TITLE
Fixed an issue where RAML 0.8 with remote reference was not working correctly.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get Code
+        uses: actions/checkout@v3
+      - name: Setup Node JS
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ out.json
 
 #vscode
 .vscode/
+
+### OSX template
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Test and coverage reports
+.tmp/
+.coverage/
+.nyc_output/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 sample_files
 node_modules
+test/
+scripts/

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -41,9 +41,25 @@ var converter = {
         });
     },
 
+    /**
+     * Removes !include statement from RAML spec and marks them as non-resolved so Parse can parse it correctly.
+     * 
+     * @param {string} ramlString - RAML 0.8 string from which to skip !include statements
+     * @returns - Skipped RAML 0.8 string
+     */
+    skipIncludes: function (ramlString) {
+        if (typeof ramlString !== 'string') {
+            return ramlString;
+        }
+
+        return ramlString.replace(/!include (\S+)/gm, 'Could not resolve "$1"');
+    },
+
     parseString: function(ramlString, callback, callbackError) {
-        var oldThis = this;
-        raml.load(ramlString).then(function(data) {
+        var oldThis = this,
+            skippedRAMLString = oldThis.skipIncludes(ramlString);
+
+        raml.load(skippedRAMLString).then(function(data) {
             try {
                 oldThis.convert(data);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,500 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.21.3",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.3",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.21.3",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
+    },
+    "@babel/helper-function-name": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.20.2"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.21.3",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
     "JSV": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
+      "integrity": "sha512-ZJ6wx9xaKJ3yFUhq5/sk82PJMuUyLk277I8mQeyDgCTjGdjWJIvPfaU5LIXaMuaN2UO1X3kZH4+lgphublZUHw=="
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -17,12 +507,76 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
+      }
+    },
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "requires": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
       }
     },
     "call-me-maybe": {
@@ -30,15 +584,146 @@
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001467",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001467.tgz",
+      "integrity": "sha512-cEdN/5e+RPikvl9AHm4uuLXxeCNq8rFsQ+lPHTfe/OtypP3WwnVVbjn+6uBV7PaFL6xUFzTh+sSCOz1rKhcO+Q==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
     },
     "debug": {
       "version": "3.1.0",
@@ -47,6 +732,36 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "default-require-extensions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      }
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
     },
     "duplexify": {
       "version": "3.5.4",
@@ -59,6 +774,18 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.4.332",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.332.tgz",
+      "integrity": "sha512-c1Vbv5tuUlBFp0mb3mCIjw+REEsgthRgNE8BlbEDKmvzb8rxjcVki6OkQP83vLN34s0XCxpSkq7AZNep1a6xhw==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -67,20 +794,167 @@
         "once": "^1.4.0"
       }
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "format-util": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+    },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "got": {
       "version": "2.4.0",
@@ -105,30 +979,275 @@
         }
       }
     },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        }
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "infinity-agent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz",
       "integrity": "sha1-Lp2iwHC5hkqLxmwBlOF5HtgFgCU="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
     "jju": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz",
       "integrity": "sha1-7fbsINXWaMgMLADOpj+KlCKktSg="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -139,10 +1258,16 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "jsface": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/jsface/-/jsface-2.2.0.tgz",
-      "integrity": "sha1-litYZ1Tasy70L2+knJpssAKxnbE="
+      "integrity": "sha512-ms6d4xSRECRFrAiMgRgcWrmZTGaTsWlLBJCZR3Xroh2B5hlmLPFu+vBHvhUCboLzzMv56h6MuvNRpjJC5qixZQ=="
     },
     "json-schema-ref-parser": {
       "version": "3.3.1",
@@ -157,10 +1282,31 @@
         "z-schema": "^3.18.2"
       }
     },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -172,15 +1318,311 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^2.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
+      }
+    },
+    "mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true
+    },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
+    "node-releases": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "nyc": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -203,10 +1645,139 @@
         "format-util": "^1.0.3"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
+    },
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
     },
     "pluralize": {
       "version": "1.1.6",
@@ -234,6 +1805,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
+    },
     "q": {
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
@@ -251,6 +1831,15 @@
         "pluralize": "~1.1.1",
         "q": "0.9.7",
         "uritemplate": "~0.3.4"
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "read-all-stream": {
@@ -272,10 +1861,117 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -292,6 +1988,17 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -300,10 +2007,108 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "timed-out": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
     },
     "uritemplate": {
       "version": "0.3.4",
@@ -325,10 +2130,105 @@
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
       "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "dev": true
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     },
     "z-schema": {
       "version": "3.19.1",

--- a/package.json
+++ b/package.json
@@ -13,19 +13,24 @@
     "raml2postman": "./bin/raml2postman"
   },
   "dependencies": {
-    "async": "*",
+    "async": "^3.2.4",
     "commander": ">=2.15.1",
     "lodash": "4.17.21",
     "path-browserify": "^1.0.1",
     "postman_validator": ">= 0.0.4",
-    "raml-parser": ">= 0.8.7",
+    "raml-parser": "0.8.18",
     "uuid": ">=3.2.1"
   },
   "author": "Postman Labs <help@getpostman.com>",
   "license": "Apache",
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "4.3.6",
+    "mocha": "10.2.0",
+    "nyc": "15.1.0"
+  },
   "scripts": {
     "release": "./scripts/release.sh",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./scripts/test.sh",
+    "test-unit": "./scripts/test-unit.sh"
   }
 }

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------------------------------------------------
+# This script is intended to execute all app and repository unit and integration tests.
+# ----------------------------------------------------------------------------------------------------------------------
+
+# stop on first error
+set -e;
+
+# function to be called on exit
+# and ensure cleanup is called before the script exits
+function cleanup {
+  unset XUNIT_FILE;
+
+  if [ "$?" != "0" ]; then
+    exit 1;
+  fi
+}
+trap cleanup EXIT;
+
+# set file for xunit report
+export XUNIT_FILE=".tmp/report.xml";
+
+# run mocha tests
+echo -e "\033[93mRunning mocha unit tests...\033[0m";
+echo -en "\033[0m\033[2mmocha `mocha --version`\033[0m";
+
+# set mocha reporter
+if [ "$CI" = "true" ]; then
+  MOCHA_REPORTER="xunit";
+  COVERAGE_REPORT="--report cobertura";
+else
+  MOCHA_REPORTER="spec";
+  COVERAGE_REPORT="";
+fi
+
+# delete old repor directory
+[ -d .coverage ] && rm -rf .coverage && mkdir .coverage;
+
+# run test
+node --max-old-space-size=2048 ./node_modules/.bin/nyc ${COVERAGE_REPORT} --report-dir ./.coverage \
+  -x **/assets/** --print both ./node_modules/.bin/_mocha \
+  --reporter ${MOCHA_REPORTER} --reporter-options output=${XUNIT_FILE} \
+  "test/unit/**.test.js" --recursive --prof --grep "$1";

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------------------------------------------------
+# This script is intended to be executed as all-inclusive test and artefact creation (excluding packaging and release.)
+# As such, a clean exit from this script implies all tests have passed and the code will not fail a build. (However,
+# build may still fail due to errors on build executing servers and as such has no relation with code quality.)
+#
+# This script executes all non time-bound tests, excluding browser tests and performance tests.
+# ----------------------------------------------------------------------------------------------------------------------
+
+# Stop on first error
+set -e;
+
+# information block
+
+# TODO - Add ASCII art banner for Cloud API
+
+echo -e "\033[0m\033[2m";
+date;
+echo "node `node -v`";
+echo "npm  v`npm -v`";
+which git &>/dev/null && git --version;
+echo -e "\033[0m";
+
+# git version
+which git &>/dev/null && \
+  echo -e "Running on branch: \033[4m`git rev-parse --abbrev-ref HEAD`\033[0m (${NODE_ENV:=development} environment)";
+
+# run unit tests
+npm run test-unit;
+
+

--- a/test/fixtures/valid-raml/api.raml
+++ b/test/fixtures/valid-raml/api.raml
@@ -1,0 +1,257 @@
+#%RAML 0.8
+---
+title: Remote Vending API
+version: v1.0
+baseUri: http://remote-vending/api
+mediaType: application/json
+schemas:
+  - post-sale: |
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type" : "object",
+        "properties" : {
+          "machineId" : {
+            "type" : "string"
+          },
+          "trayId" : {
+            "type" : "string"
+          },
+          "dateAndTime" : {
+            "type" : "string"
+          },
+          "exchange" : {
+            "type" : "object",
+            "properties" : {
+              "value" : {
+                "type" : "integer"
+              },
+              "in" : {
+                "type" : "integer"
+              },
+              "out" : {
+                "type" : "integer"
+              }
+            }
+          }
+        }    
+      }
+  - get-sales: |
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer"
+          },
+          "sales" : {
+            "type" : "array",
+            "items" : {
+                "type" : "object",
+                "properties" : {
+                  "dateAndTime" : {
+                    "type" : "string"
+                  },
+                  "value" : {
+                    "type" : "integer"
+                  },
+                  "machineId" : {
+                    "type" : "string"
+                  },
+                  "productId" : {
+                    "type" : "string"
+                  }
+                }
+              }
+          },
+          "totalValue" : "integer"
+        }    
+      }
+  - get-machines: |
+     {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer"
+          },
+          "machines" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+                "properties" : {
+                  "id" : {
+                    "type" : "string"
+                  },
+                  "location" : {
+                    "type" : "string"
+                  }
+                }
+              }
+          }
+        }    
+      }
+  - get-machine: |
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "location" : {
+            "type" : "string"
+          },
+          "sales" : {
+            "type" : "array",
+            "items" : {
+                "type" : "object",
+                "properties" : {
+                  "dateTime" : {
+                    "type" : "string"
+                  },
+                  "productId" : {
+                    "type" : "string"
+                  }
+                }
+              }
+          },
+          "floatsToBeReplenished" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer"
+            }
+          },
+          "stockToBeReplenished" : {
+            "type" : "integer"
+          }
+        }    
+      }
+documentation:
+  - title: Introduction
+    content: |
+      API to manage the sales and replenishments of stock items and floats in our vending machines.
+resourceTypes: 
+  - base:
+      get:
+        responses:
+          200:
+            body:
+              schema: get-<<resourcePathName>> # e.g. get-machines
+  - collection:
+      type: base
+      post:
+        body:
+          schema: post-<<resourcePathName | !singularize>>  # e.g. post-sale
+        responses:
+          201:
+            description: Created!
+            headers:
+              Location:
+                description: uri of new resource
+                type: string
+                required: true  
+traits:
+  - filterable:
+      queryParameters:
+        stockLevel:
+          displayName: Stock Level
+          description: Percentage of trays with stock items in them.
+          type: string
+          required: false
+          example: stockLevel=20
+        floatLevel:
+          displayName: Float Level
+          description: Percentage of monetary units present in the float.
+          type: string
+          required: false
+          example: floatLevel=80
+/sales:
+  type: collection
+  post:
+    body:
+      example: |
+        {
+            "machineId" : "ZX4102",
+            "trayId" : "A1",
+            "dateAndTime" : "2013-10-22 16:17:00",
+            "exchange" : {
+                "value" : 450,
+                "in" : 500,
+                "out" : 50
+            } 
+        }
+  get:
+    responses:
+      200:
+        body:
+          example: |
+            {
+                "count" : 2,
+                "sales" : [
+                  {
+                    "dateAndTime" : "2013-10-22 16:17:00",
+                    "value" : 450,
+                    "machineId" : "ZX4102",
+                    "productId" : "Cad-CB1012"
+                  },
+                  {
+                    "dateAndTime" : "2013-10-22 16:17:00",
+                    "value" : 150,
+                    "machineId" : "ZX5322",
+                    "productId" : "CC-LB1"
+                  }
+                ],
+                "totalValue" : 600
+            }
+/machines:
+  type: base
+  get:
+    is: [filterable]
+    responses:
+      200:
+        body:
+          example: |
+            {
+                "count" : 3,
+                "machines" : [
+                  {
+                    "id" : "ZX4102",
+                    "location" : "Starbuck's, 442 Geary Street, San Francisco, CA 94102"
+                  },
+                  {
+                    "id" : "ZX5322",
+                    "location" : "Starbuck's, 462 Powell Street, San Francisco, CA 94102"
+                  },
+                  {
+                    "id" : "ZX6792",
+                    "location" : "Cafe La Taza, 470 Post Street, San Francisco, CA 94102"
+                  }
+                ]
+            }
+  /{machine}:
+    type: base
+    get:
+      responses:
+        200:
+          body:
+            example: |
+              {
+                  "id" : "ZX4102",
+                  "location" : "Starbuck's, 442 Geary Street, San Francisco, CA 94102",
+                  "sales" : [
+                    {
+                      "dateAndTime" : "2013-10-22 16:17:00",
+                      "value" : 450,
+                      "machineId" : "ZX4102",
+                      "productId" : "Cad-CB1012"
+                    },
+                    {
+                      "dateAndTime" : "2013-10-22 16:17:00",
+                      "value" : 150,
+                      "machineId" : "ZX5322",
+                      "productId" : "CC-LB1"
+                    }
+                  ],
+                  "floatsToBeReplenished" : [20, 40, 20, 80, 20, 40, 40],
+                  "stockToBeReplenished" : 54
+              }

--- a/test/fixtures/valid-raml/remoteRefs.raml
+++ b/test/fixtures/valid-raml/remoteRefs.raml
@@ -1,0 +1,1430 @@
+#%RAML 0.8
+title: Zephyr Scale Server API (v1)
+version: 1.0
+baseUri: /rest/atm/{version}
+documentation:
+  - title: Getting Started
+    content: |
+      ## Accessing the API
+      The Zephyr Scale REST API is ready to use if you have Zephyr Scale installed on your JIRA instance.
+      All API uses the following base URL:
+      ```
+      http://your-jira-host:port/your-jira-context/rest/atm/1.0/
+      ```
+      For instance, you can create test results using the "testresult" api:
+      ```
+      POST http://localhost:2990/jira/rest/atm/1.0/testresult
+      ```
+      ## Authentication Basics
+      Any authentication that works with JIRA will work with the Zephyr Scale REST API.
+      The prefered authentication methods are OAuth and HTTP Basic. See the [JIRA SERVER REST API](https://developer.atlassian.com/server/jira/platform/rest-apis) docs for details.
+      ## Using Status and Environment Fields
+      Some entities, such as the Test Results, may have status and environment fields. The values of these fields are identified by name, not by the localized name.
+      Both fields may have custom values defined by the user on the Zephyr Scale configuration area. All values are **case sensitive**, and they must be set just as displayed on the add-on.
+
+      These are the default values, which must be used on the APIs instead of their localized versions:
+      * Test Cases:
+        * Draft
+        * Approved
+        * Deprecated
+
+      * Test Runs:
+        * Not Executed
+        * In Progress
+        * Done
+
+      * Test Results:
+        * Not Executed
+        * In Progress
+        * Pass
+        * Fail
+        * Blocked
+      ## Handling Date Format
+      The API supports the ISO 8601 format for date/time fields. This allows you to pass in the level of detail you need to. When a field is not specified, the earliest possible value is the default. For example, if you do not specify a time of day, we will default to 00:00 (midnight). Similarly, not specifying a timezone defaults the timezone to GMT. The full representation is of the format:
+      ```
+      yyyy-MM-ddTHH:mm:ss.SSSZ
+      ```
+      This table illustrates some example valid dates and times:
+
+      | Input | Equivalent to |
+      | ------ | ----------- |
+      | 2016 | 2016-01-01T00:00:00.000Z |
+      | 2016-04 | 2016-04-01T00:00:00.000Z |
+      | 2016-04-15 | 2016-04-15T00:00:00.000Z |
+      | 2016-04-15T16 | 2016-04-15T16:00:00.000Z |
+      | 2016-04-15T16:15 | 2016-04-15T16:15:00.000Z |
+      | 2016-04-15T16:15Z | 2016-04-15T16:15:00.000Z (GMT time zone) |
+      | 2016-04-15T16:15-0300 | 2016-04-15T16:15:00.000-0300 (Brazil time zone) |
+
+securitySchemes:
+  - oauth:
+      description: |
+          See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+      type: OAuth 1.0
+      settings:
+        requestTokenUri: JIRA_BASE_URL + "/plugins/servlet/oauth/request-token"
+        authorizationUri: JIRA_BASE_URL + "/plugins/servlet/oauth/authorize"
+        tokenCredentialsUri: JIRA_BASE_URL + "/plugins/servlet/oauth/access-token"
+  - basic:
+      description: |
+          See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+      type: Basic Authentication
+schemas:
+  - testresult: !include testresult.schema
+  - embeddedtestresult: !include embeddedtestresult.schema
+  - testcase: !include testcase.schema
+  - testrun: !include testrun.schema
+  - folder: !include folder.schema
+  - environment: !include environment.schema
+  - project: !include project.schema
+  - customfield: !include customfield.schema
+  - customfieldoption: !include customfieldoption.schema
+  - executiondeletion: !include executiondeletion.schema
+
+/testcase:
+  displayName: Test Case
+  post:
+    description: |
+      Creates a new Test Case.
+
+      Whitespace is not allowed for labels, and it will be replaced by an underscore character.
+      The field ```type``` of Test Script can have the values ```PLAIN_TEXT```, ```STEP_BY_STEP``` or ```BDD```. The field ```text``` describes the content of the plain text or BDD test script; otherwise, the steps can be described as objects using the field ```steps```.
+      Call To Tests can be added to the steps list by using the field ```testCaseKey``` with a Test Case key as value.
+      The optional field ```folder```, if defined, must contain an existent folder name. No folder will be created.
+      The fields ```status``` and ```priority``` will be set to default values if not defined.
+      The optional field parameters has two attributes: variables and entries. For attribute variables, two types are allowed: FREE_TEXT and DATA_SET. If using DATA_SET, an extra field should be informed, having the name of the dataset. If the dataset doesn’t exist, it will be automatically created. Attribute entries must only have values matching the informed variables. If a value of a dataset doesn’t exist, it will be automatically created for that dataset. Check the examples below for more details.
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: testcase
+        example: !include testcase_post.example
+    responses:
+      201:
+        description: The Test Case was successfully created.
+        body:
+          application/json:
+            example: !include testcase_response_key.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include testcase_response_fielderror.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+  /{testCaseKey}:
+    displayName: Test Case
+    uriParameters:
+      testCaseKey:
+        description: The key of the Test Case.
+        type: string
+        example: JQA-T1234
+    get:
+      description: |
+        Retrieve the Test Case matching the given key.
+      queryParameters:
+        fields:
+          description: The fields of the Test Case to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+          example: key,name,folder,status,priority,component,owner,estimatedTime,labels,customFields,issueLinks
+          type: string
+          required: false
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Case was successfully retrieved.
+          body:
+            application/json:
+              example: !include testcase_get.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Case has been found with the given key.
+    put:
+      description: |
+        Updates a Test Case.
+
+        Whitespace is not allowed for labels, and it will be replaced by an underscore character.
+        The field ```type``` of Test Script can have the values ```PLAIN_TEXT```, ```STEP_BY_STEP``` or ```BDD```. The field ```text``` describes the content of the plain text or BDD test script; otherwise, the steps can be described as objects using the field ```steps```.
+        The field ```folder```, if defined, must contain an existent folder name. No folder will be created.
+        Only fields present on the body will be updated. The field ```projectKey``` cannot be changed.
+        Call To Tests can be added to the steps list by using the field ```testCaseKey``` with a Test Case key as value.
+        The optional field parameters has two attributes: variables and entries. For attribute variables, two types are allowed: FREE_TEXT and DATA_SET. If using DATA_SET, an extra field should be informed, having the name of the dataset. If the dataset doesn’t exist, it will be automatically created. Attribute entries must only have values matching the informed variables. If a value of a dataset doesn’t exist, it will be automatically created for that dataset. Check the examples below for more details.
+        For the field ```testScript```, when it is a step-by-step script:
+        * If some step is missing in comparison to the target Test Case, it will be deleted.
+        * Steps not having ```id``` will be considered as a new step and will be created.
+        * Steps having ```id``` will be considered as existing steps and will be updated.
+      securedBy: [oauth, basic]
+      body:
+        application/json:
+          schema: testcase
+          example: !include testcase_put.example
+      responses:
+        200:
+          description: The Test Case was successfully updated.
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include testcase_response_fielderror.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+    delete:
+      description: |
+        Delete the Test Case matching the given key.
+      securedBy: [oauth, basic]
+      responses:
+        204:
+          description: The Test Case was successfully deleted.
+        404:
+          description: No Test Case has been found with the given key.
+    /attachments:
+      displayName: Test Case Attachments
+      post:
+        description: Create a new attachment on the specified Test Case.
+        securedBy: [oauth, basic]
+        body:
+          multipart/form-data:
+            formParameters:
+              file:
+                description: The file to be uploaded, using ```multipart/form-data``` content type.
+                required: true
+                type: file
+        responses:
+          201:
+            description: The attachment was successfully created.
+            body:
+              application/json:
+                example: !include attachment_response_id.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Case has been found with the given key.
+      get:
+        description: |
+          Retrieve the Test Case Attachments matching the given key.
+        securedBy: [oauth, basic]
+        responses:
+          200:
+            description: The Test Case Attachments were successfully retrieved.
+            body:
+              application/json:
+                example: !include attachments_get.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Case has been found with the given key.
+    /testresult/latest:
+      displayName: Test Case Latest Result
+      get:
+        description: Retrieve the last test result for a given key
+        securedBy: [oauth, basic]
+        responses:
+          200:
+            description: The Last Test Result was successfully retrieved.
+            body:
+              application/json:
+                example: !include last_test_result_by_test_case.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Case has been found with the given key or the Test Case has no results.
+    /step/{stepIndex}/attachments:
+      displayName: Test Case Step Attachments
+      uriParameters:
+       stepIndex:
+        description: The index of the Test Case step.
+        type: integer
+        example: 1
+      get:
+        description: Retrieve the attachments for a test case step
+        securedBy: [oauth, basic]
+        responses:
+          200:
+            description: The test case step attachment was successfully retrieved.
+            body:
+              application/json:
+                example: !include attachments_get.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Case has been found with the given key or the Step Index was not found.
+      post:
+        description: Create a new attachment on the specified Step of a Test Case.
+        securedBy: [oauth, basic]
+        body:
+          multipart/form-data:
+            formParameters:
+              file:
+                description: The file to be uploaded, using ```multipart/form-data``` content type.
+                required: true
+                type: file
+        responses:
+          201:
+            description: The attachment was successfully created.
+            body:
+              application/json:
+                example: !include attachment_response_id.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Case has been found with the given key or the Step Index was not found.
+  /search:
+    displayName: Search Test Cases
+    get:
+      description: |
+        Retrieve the Test Cases that matches the query passed as parameter.
+      queryParameters:
+        fields:
+          description: The fields of the Test Case to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+          example: key,name,folder,status,priority,component,owner,estimatedTime,labels,customFields,issueLinks
+          type: string
+          required: false
+        query:
+          description: |
+            A query to filter Test Cases. The query syntax is similar to the JIRA JQL.
+
+            * Available fields: ```projectKey```, ```key```, ```name```, ```status```, ```priority```, ```component```, ```folder```, ```estimatedTime```, ```labels```, ```owner``` and custom fields. When filtering by custom fields, the field name must be quoted.
+            * Available operators: ```=```, ```>```, ```>=```, ```<```, ```<=```, ```IN```
+            * For Single and Multi Choice custom fields, operator "=" is not supported, use "IN" instead
+            * Available logical operators: ```AND```
+
+            It is always a good idea considering using the ```projectKey``` field to match values that only belongs to that project, such as statuses, folders, etc.
+
+            Folders always have to start with a "/", for instance: "/a folder". The "/" matches the root, above all folders.
+
+            The query syntax is very strict. The use of whitespaces between fields, operators and logical operators is required, as well as the use of double quotes for string values.
+
+            Usage examples:
+            * projectKey = "JQA" AND status = "Draft" AND priority = "High"
+            * projectKey = "JQA" AND status IN ("Draft", "Deprecated") AND labels IN ("Functional", "UI")
+            * projectKey = "JQA" AND status IN ("Draft", "Deprecated") AND labels IN ("Functional", "UI")
+            * projectKey = "JQA" AND status = "Draft" AND folder = "/"
+            * projectKey = "JQA" AND folder = "/folder with some test cases"
+            * projectKey = "JQA" AND folder = "/folder with some test cases/child folder"
+            * projectKey = "JQA" AND folder IN ("/parent folder", "/parent folder/child folder")
+            * projectKey = "JQA" AND "My Custom Field" = "Some value"
+            * projectKey = "JQA" AND "Single Choice Custom Field" IN ("Some value")
+            * projectKey = "JQA" AND "Multi Choice Custom Field" IN ("Some value", "Another value")
+            * projectKey = "JQA" AND issueKeys IN ("JQA-5", "JQA-4")
+            * key IN ("JQA-T50", "JTQ-T90")
+            * key IN ("JQA-T50", "JTQ-T90") AND name = "My Test Case Name"
+          example: projectKey = "JQA" AND status = "Draft" AND priority = "High"
+          type: string
+          required: false
+        startAt:
+          description: An offset to use with the query. This can be useful when paginating results.
+          example: 10
+          type: integer
+          required: false
+        maxResults:
+          description: The max result count, limiting the query results. If not provided, the default value of 200 will be used.
+          example: 100
+          type: integer
+          required: false
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Cases were successfully retrieved.
+          body:
+            application/json:
+              example: !include testcases_get.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include testcase_search_response_error.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+/testplan:
+  post:
+    description: |
+      Creates a new Test Plan.
+
+      Whitespace is not allowed for labels, and it will be replaced by an underscore character.
+      The optional field ```folder```, if defined, must contain an existent folder name. No folder will be created.
+      The field ```status``` will be set to a default value if not defined.
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: testplan
+        example: !include testplan_post.example
+    responses:
+      201:
+        description: The Test Plan was successfully created.
+        body:
+          application/json:
+            example: !include testplan_response_key.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include testplan_response_fielderror.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+  /{testPlanKey}:
+    displayName: Test Plan
+    uriParameters:
+      testPlanKey:
+        description: The key of the Test Plan.
+        type: string
+        example: JQA-P1234
+    put:
+      description: |
+        Updates a Test Plan.
+
+        Whitespace is not allowed for labels, and it will be replaced by an underscore character.
+        The optional field ```folder```, if defined, must contain an existent folder name. No folder will be created.
+        The field ```status``` will be set to a default value if not defined.
+      securedBy: [oauth, basic]
+      body:
+        application/json:
+          schema: testplan
+          example: !include testplan_post.example
+      responses:
+        200:
+          description: The Test Plan was successfully updated.
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include testplan_response_fielderror.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+    get:
+      description: |
+        Retrieve the Test Plan matching the given key.
+      queryParameters:
+        fields:
+          description: The fields of the Test Plan to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+          example: key,name,status,objective,testRuns,customFields
+          type: string
+          required: false
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Plan was successfully retrieved.
+          body:
+            application/json:
+              example: !include testplan_get.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Plan has been found with the given key.
+    delete:
+      description: |
+        Delete the Test Plan matching the given key.
+      securedBy: [oauth, basic]
+      responses:
+        204:
+          description: The Test Plan was successfully deleted.
+        404:
+          description: No Test Plan has been found with the given key.
+    /attachments:
+      displayName: Test Plan Attachment
+      post:
+        description: Create a new attachment on the specified Test Plan.
+        securedBy: [oauth, basic]
+        body:
+          multipart/form-data:
+            formParameters:
+              file:
+                description: The file to be uploaded, using ```multipart/form-data``` content type.
+                required: true
+                type: file
+        responses:
+          201:
+            description: The attachment was successfully created.
+            body:
+              application/json:
+                example: !include attachment_response_id.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Plan has been found with the given key.
+      get:
+        description: |
+          Retrieve the Test Plan Attachments matching the given key.
+        securedBy: [oauth, basic]
+        responses:
+          200:
+            description: The Test Plan Attachments were successfully retrieved.
+            body:
+              application/json:
+                example: !include attachments_get.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Plan has been found with the given key.
+  /search:
+    displayName: Search Test Plans
+    get:
+      description: |
+        Retrieve the Test Plans that matches the query passed as parameter.
+      queryParameters:
+        fields:
+          description: The fields of the Test Plan to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+          example: key,name,folder,status,owner,labels,customFields
+          type: string
+          required: false
+        query:
+          description: |
+            A query to filter Test Plans. The query syntax is similar to the JIRA JQL.
+
+            * Available fields: ```projectKey```, ```key```, ```name```, ```status```, ```folder```, ```labels```, ```owner```, ```issueKeys``` and custom fields. When filtering by custom fields, the field name must be quoted.
+            * Available operators: ```=```, ```>```, ```>=```, ```<```, ```<=```, ```IN```
+            * For Single and Multi Choice custom fields, operator "=" is not supported, use "IN" instead
+            * Available logical operators: ```AND```
+
+            It is always a good idea considering using the ```projectKey``` field to match values that only belongs to that project, such as statuses, folders, etc.
+
+            Folders always have to start with a "/", for instance: "/a folder". The "/" matches the root, above all folders.
+
+            The query syntax is very strict. The use of whitespaces between fields, operators and logical operators is required, as well as the use of double quotes for string values.
+
+            Usage examples:
+            * projectKey = "JQA" AND status = "Draft"
+            * projectKey = "JQA" AND status IN ("Draft", "Deprecated") AND labels IN ("Functional", "UI")
+            * projectKey = "JQA" AND status = "Draft" AND folder = "/"
+            * projectKey = "JQA" AND folder = "/folder with some test plans"
+            * projectKey = "JQA" AND folder = "/folder with some test plans/child folder"
+            * projectKey = "JQA" AND folder IN ("/parent folder", "/parent folder/child folder")
+            * projectKey = "JQA" AND "My Custom Field" = "Some value"
+            * projectKey = "JQA" AND "Single Choice Custom Field" IN ("Some value")
+            * projectKey = "JQA" AND "Multi Choice Custom Field" IN ("Some value", "Another value")
+            * projectKey = "JQA" AND issueKeys IN ("JQA-5", "JQA-4")
+          example: projectKey = "JQA" AND status = "Draft"
+          type: string
+          required: false
+        startAt:
+          description: An offset to use with the query. This can be useful when paginating results.
+          example: 10
+          type: integer
+          required: false
+        maxResults:
+          description: The max result count, limiting the query results. If not provided, the default value of 200 will be used.
+          example: 100
+          type: integer
+          required: false
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Plans were successfully retrieved.
+          body:
+            application/json:
+              example: !include testplans_get.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include testcase_search_response_error.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+
+/testrun:
+  displayName: Test Run
+  securedBy: [oauth, basic]
+  post:
+    description: |
+      Creates a new Test Run.
+
+      The fields ```plannedStartDate``` and ```plannedEndDate``` will be set to default values if not defined.
+      The field ```status``` will be automatically inferred based on the status of Test Run Items (field ```items```).
+      The Test Run can be linked to a Test Plan, by setting a valid value on field testPlanKey. Also, it can be linked to an issue, by setting a valid value on field issueKey.
+      All Test Result fields are allowed for Test Run Items (field ```items```).
+    body:
+      application/json:
+        schema: testrun
+        example: !include testrun_post.example
+    responses:
+      201:
+        description: The Test Run was successfully created.
+        body:
+          application/json:
+            example: !include testrun_response_key.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include testrun_response_fielderror.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+  /{testRunKey}:
+    displayName: Test Run
+    uriParameters:
+      testRunKey:
+        description: The key of the Test Run.
+        type: string
+        example: JQA-R1234
+    get:
+      description: |
+        Retrieve the Test Run matching the given key.
+      queryParameters:
+        fields:
+          description: The fields of the Test Run to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+          example: key,name,version,iteration,items
+          type: string
+          required: false
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Run was successfully retrieved.
+          body:
+            application/json:
+              example: !include testrun_get.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Run has been found with the given key.
+    delete:
+      description: |
+        Delete the Test Run matching the given key.
+      securedBy: [oauth, basic]
+      responses:
+        204:
+          description: The Test Run was successfully deleted.
+        404:
+          description: No Test Run has been found with the given key.
+    /attachments:
+      displayName: Test Run Attachment
+      post:
+        description: Create a new attachment on the specified Test Run.
+        securedBy: [oauth, basic]
+        body:
+          multipart/form-data:
+            formParameters:
+              file:
+                description: The file to be uploaded, using ```multipart/form-data``` content type.
+                required: true
+                type: file
+        responses:
+          201:
+            description: The attachment was successfully created.
+            body:
+              application/json:
+                example: !include attachment_response_id.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Run has been found with the given key.
+      get:
+        description: |
+          Retrieve the Test Run Attachments matching the given key.
+        securedBy: [oauth, basic]
+        responses:
+          200:
+            description: The Test Run Attachments were successfully retrieved.
+            body:
+              application/json:
+                example: !include attachments_get.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+          404:
+            description: No Test Run has been found with the given key.
+
+    /testcase/{testCaseKey}/testresult:
+      displayName: Test Result of Test Run
+      securedBy: [oauth, basic]
+      uriParameters:
+        testCaseKey:
+          description: The key of the Test Case
+          type: string
+          example: JQA-T1234
+      post:
+        description: |
+          Creates a new Test Result on the specified Test Run, looking for an item that matches the ```testCaseKey``` and the query string filter parameters.
+          If more than one item is found using the specified parameters, only the first one of them will have the new Test Result created.
+          Once created, the new Test Result can be seen inside the specified Test Run, looking for a Test Case that matches the request parameters.
+          The fields ```actualStartDate```, ```actualEndDate``` and ```status``` will be set to default values if not defined.
+
+          Deprecation notice - The fields ```executionDate``` and ```userKey``` are deprecated. Please use their new equivalents:
+
+          ```executionDate``` is now represented by ```actualEndDate```
+
+          ```userKey``` is now represented by ```executedBy```
+
+        queryParameters:
+          environment:
+            description: The environment to be optionally matched by an item on the Test Run.
+            example: Firefox
+            type: string
+          userKey:
+            description: The user key to be optionally matched by an item on the Test Run.
+            example: vitor.pelizza
+            type: string
+        body:
+          application/json:
+            schema: embeddedtestresult
+            example: !include embeddedtestresult_post.example
+        responses:
+          201:
+            description: The Test Result was successfully created.
+            body:
+              application/json:
+                example: !include testresult_response_id.example
+          400:
+            description: Some parameters are invalid or not found.
+            body:
+              application/json:
+                example: !include testresult_response_fielderror.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+      put:
+        description: |
+          Updates the last Test Result on the specified Test Run, looking for an item that matches the testCaseKey and the query string filter parameters. Only defined fields will be updated.
+          If more than one item is found using the specified parameters, only the first one of them will have the Test Result updated.
+          The updated data can be seen inside the specified Test Run, looking for the last Test Results of the Test Case that matches the request parameters.
+        queryParameters:
+          environment:
+            description: The environment to be optionally matched by an item on the Test Run.
+            example: Firefox
+            type: string
+          userKey:
+            description: The user key to be optionally matched by an item on the Test Run.
+            example: vitor.pelizza
+            type: string
+        body:
+          application/json:
+              schema: embeddedtestresult
+              example: !include embeddedtestresult_post.example
+        responses:
+          200:
+            description: The last Test Result was successfully updated.
+            body:
+              application/json:
+                example: !include testresult_response_id.example
+          400:
+            description: Some parameters are invalid or not found.
+            body:
+              application/json:
+                example: !include testresult_response_fielderror.example
+          401:
+            description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+            body:
+              application/json:
+                example: !include response_autherror.example
+
+  /{testRunKey}/testresults:
+    displayName: Retrieve All Test Results linked to a Test Run.
+    uriParameters:
+      testRunKey:
+        description: The key of the Test Run.
+        type: string
+        example: JQA-R1234
+    post:
+      description: |
+        Create new Test Results on the specified Test Run, looking for items that match the ```testCaseKey``` for each body item.
+        Once created, the new Test Results can be seen inside the specified Test Run, looking for Test Cases that match the request parameters.
+        The fields ```actualStartDate```, ```actualEndDate``` and ```status``` will be set to default values if not defined.
+
+        Deprecation notice - The fields ```executionDate``` and ```userKey``` are deprecated. Please use their new equivalents:
+
+        ```executionDate``` is now represented by ```actualEndDate```
+
+        ```userKey``` is now represented by ```executedBy```
+
+      queryParameters:
+        environment:
+          description: The environment to be optionally matched by an item on the Test Run.
+          example: Firefox
+          type: string
+        userKey:
+          description: The user key to be optionally matched by an item on the Test Run.
+          example: vitor.pelizza
+          type: string
+      body:
+        application/json:
+          schema: embeddedtestresult
+          example: !include embeddedtestresults_post.example
+      responses:
+        201:
+          description: The Test Results were successfully created.
+          body:
+            application/json:
+              example: !include testresult_response_ids.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include testresult_response_fielderror.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+    get:
+      description: |
+        Retrieve All Test Results linked to a Test Run.
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Result list was successfully retrieved.
+          body:
+            application/json:
+              example: !include testresults_by_testrun_get.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Run has been found with the given key.
+
+  /search:
+    displayName: Search Test Runs
+    get:
+      description: |
+        Retrieve the Test Runs that matches the query passed as parameter.
+      queryParameters:
+        fields:
+          description: The fields of the Test Run to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+          example: key,name,version,iteration,items
+          type: string
+          required: false
+        query:
+          description: |
+            A query to filter Test Runs. The query syntax is similar to the JIRA JQL.
+
+            * Available fields: ```projectKey```, ```folder```
+            * Available operators: ```=```, ```IN```
+            * Available logical operators: ```AND```
+
+            The query syntax is very strict. The use of whitespaces between fields, operators and logical operators is required, as well as the use of double quotes for string values.
+
+            Usage example:
+            * projectKey = "JQA"
+            * projectKey IN ("JQA", "DEF")
+            * projectKey = "JQA" AND folder = "/Orbiter"
+            * projectKey IN ("JQA", "DEF") AND folder = "/Orbiter/Propellant"
+            * folder = "/Orbiter"
+          type: string
+          required: false
+        startAt:
+          description: An offset to use with the query. This can be useful when paginating results.
+          example: 10
+          type: integer
+          required: false
+        maxResults:
+          description: The max result count, limiting the query results. If not provided, the default value of 200 will be used.
+          example: 100
+          type: integer
+          required: false
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Runs were successfully retrieved.
+          body:
+            application/json:
+              example: !include testruns_get.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include testrun_search_response_error.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+/testresult:
+  displayName: Test Results
+  post:
+    description: |
+      Creates a new Test Result for a Test Case.
+
+      Once created, a new Test Result can be seen on the "Execution" tab of the specified Test Case. This Test Result is not linked with any Test Run.
+      The fields ```actualStartDate```, ```actualEndDate``` and ```status``` will be set to default values if not defined.
+
+      Deprecation notice - The fields ```executionDate``` and ```userKey``` are deprecated. Please use their new equivalents:
+
+      ```executionDate``` is now represented by ```actualEndDate```
+
+      ```userKey``` is now represented by ```executedBy```
+
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: testresult
+        example: !include testresult_post.example
+    responses:
+      201:
+        description: The Test Result was successfully created.
+        body:
+          application/json:
+            example: !include testresult_response_id.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include testresult_response_fielderror.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+  /{testResultId}/attachments:
+    displayName: Test Result Attachment
+    uriParameters:
+      testResultId:
+        description: The id of the Test Result.
+        type: integer
+        example: 123
+    post:
+      description: Create a new attachment on the specified Test Result.
+      securedBy: [oauth, basic]
+      body:
+        multipart/form-data:
+          formParameters:
+            file:
+              description: The file to be uploaded, using ```multipart/form-data``` content type.
+              required: true
+              type: file
+      responses:
+        201:
+          description: The attachment was successfully created.
+          body:
+            application/json:
+              example: !include attachment_response_id.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Result has been found with the given id.
+    get:
+      description: Retrieve the Test Result Attachments matching the given id.
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Result Attachments were successfully retrieved.
+          body:
+            application/json:
+              example: !include attachments_get.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Case has been found with the given key.
+  /{testResultId}/step/{stepIndex}/attachments:
+    displayName: Test Result Step Attachment
+    uriParameters:
+      testResultId:
+        description: The id of the Test Result.
+        type: integer
+        example: 123
+      stepIndex:
+        description: The index of the Test Result step.
+        type: integer
+        example: 1
+    post:
+      description: Create a new attachment on the specified step of the Test Result.
+      securedBy: [oauth, basic]
+      body:
+        multipart/form-data:
+          formParameters:
+            file:
+              description: The file to be uploaded, using ```multipart/form-data``` content type.
+              required: true
+              type: file
+      responses:
+        201:
+          description: The attachment was successfully created.
+          body:
+            application/json:
+              example: !include attachment_response_id.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Result step has been found with the given id and index value.
+    get:
+      description: |
+        Retrieve the Test Result Step Attachments matching the given testResultId and stepIndex.
+      securedBy: [oauth, basic]
+      responses:
+        200:
+          description: The Test Result Step Attachments were successfully retrieved.
+          body:
+            application/json:
+              example: !include attachments_get.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+        404:
+          description: No Test Result Step has been found with the given testResultId and stepIndex.
+
+/issuelink/{issueKey}/testcases:
+  displayName: Issue Link
+  uriParameters:
+    issueKey:
+      description: The key of the linked Issue.
+      type: string
+      example: JQA-1234
+  get:
+    description: |
+      Retrieve all Test Cases linked to an Issue.
+    queryParameters:
+      fields:
+        description: The fields of the Test Case to be included on the response. If not set, all fields will be returned. Inexistent fields will be ignored.
+        example: key,name,folder,status,priority,component,owner,estimatedTime,labels,issueLinks
+        type: string
+        required: false
+    securedBy: [oauth, basic]
+    responses:
+      200:
+        description: The Test Cases were successfully retrieved.
+        body:
+          application/json:
+            example: !include testcases_get.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+      404:
+        description: No Issue has been found with the given key.
+/folder:
+  displayName: Folders
+  post:
+    description: |
+      Creates a new folder for test cases, test plans or test runs.
+
+      In order to create a new folder you must POST a json with 3 fields: projectKey, name and type. The field type can
+      be filled with TEST_CASE, TEST_PLAN or TEST_RUN.
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: folder
+        example: !include folder_post.example
+    responses:
+      201:
+        description: The Folder was successfully created.
+        body:
+          application/json:
+            example: !include folder_response_id.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include folder_response_fielderror.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+  /{folderId}:
+    displayName: Folder
+    uriParameters:
+      folderId:
+        description: The id of the Folder.
+        type: integer
+        example: 80
+    put:
+      description: |
+        Updates a folder for test cases, test plans or test runs.
+
+        You can only update the name or the custom field value of a folder, in order to do that you must PUT a json with 2 fields: name and customFields.
+        The field name is a String and forward and backslashes are not allowed.
+        The field customFields is an object with the key being the custom field name.
+      securedBy: [oauth, basic]
+      body:
+        application/json:
+          schema: folder
+          example: !include folder_put.example
+      responses:
+        200:
+          description: The Folder was successfully updated.
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include folder_update_response_fielderror.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+/attachments/{id}:
+  displayName: Attachment
+  delete:
+    description: Delete an Attachment given an id
+    securedBy: [oauth, basic]
+    responses:
+      204:
+        description: The Attachment was successfully deleted.
+      400:
+        description: The Attachment can't be deleted.
+        body:
+            application/json:
+              example: !include attachment_response_cant_delete.example
+      404:
+        description: No Attachment has been found with the given id.
+
+/environments:
+  displayName: Environments
+  get:
+    description: |
+      Retrieve the Environments matching the given projectKey.
+
+      The project must exist
+      The project must have Zephyr Scale enabled
+    queryParameters:
+      projectKey:
+        description: The key of the Project
+        example: JQA
+        type: string
+        required: true
+    securedBy: [oauth, basic]
+    responses:
+      200:
+        description: The Environments were successfully retrieved.
+        body:
+          application/json:
+            example: !include environments_get.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include environments_get_response_fielderror.example
+  post:
+    description: |
+      Creates a new Environment.
+
+      The project must exist
+      The project must have Zephyr Scale enabled
+      The name must be unique
+
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: environment
+        example: !include environments_post.example
+    responses:
+      201:
+        description: The Environment was successfully created.
+        body:
+          application/json:
+            example: !include environments_response_id.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include environments_response_post_fielderror.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+/automation/execution/{projectKey}:
+  uriParameters:
+    projectKey:
+      description: The key of the Project.
+      type: string
+      example: JQA
+  post:
+    description: |
+      Creates a new Test Cycle based on provided automated test results.
+      This endpoint receives a zip file containing one or more Zephyr Scale Test Results File Format to create the Test Cycle. See [Zephyr Scale JUnit Integration](https://bitbucket.org/smartbeartm4j/tm4j-junit-integration) to learn how to generate this file.
+      Optionally, you can send a `testCycle` part in your form data to customize the created Test Cycle.
+    securedBy: [oauth, basic]
+    body:
+      multipart/form-data:
+        formParameters:
+          file:
+            description: The file to be uploaded, using ```multipart/form-data``` content type.
+            required: true
+            type: file
+          testCycle:
+            description: A JSON object to customize the new Test Cycle.
+            required: false
+            type: string
+            example: !include automation_testcycle_formparam.example
+    responses:
+      201:
+        description: The Test Run was successfully created.
+        body:
+          application/json:
+            example: !include automation_post_response.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include automation_custom_file_response_post_error.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+
+/automation/execution/cucumber/{projectKey}:
+  uriParameters:
+    projectKey:
+      description: The key of the Project.
+      type: string
+      example: JQA
+  post:
+    description: |
+      Creates a new Test Cycle based on provided automated test results.
+      This endpoint receives a zip file containing one or more [Cucumber Json Output file](https://relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter).
+      Optionally, you can send a `testCycle` part in your form data to customize the created Test Cycle.
+    securedBy: [oauth, basic]
+    body:
+      multipart/form-data:
+        formParameters:
+          file:
+            description: The file to be uploaded, using ```multipart/form-data``` content type.
+            required: true
+            type: file
+          testCycle:
+            description: A JSON object to customize the new Test Cycle.
+            required: false
+            type: string
+            example: !include automation_testcycle_formparam.example
+    responses:
+      201:
+        description: The Test Run was successfully created.
+        body:
+          application/json:
+            example: !include automation_post_response.example
+      400:
+        description: Some parameters are invalid or not found.
+        body:
+          application/json:
+            example: !include automation_custom_file_response_post_error.example
+      401:
+        description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+        body:
+          application/json:
+            example: !include response_autherror.example
+
+/automation/testcases:
+  get:
+    description: |
+      Retrieve a zip file containing Cucumber Feature Files that matches the tql passed as parameter.
+    queryParameters:
+      tql:
+        description: |
+          A Zephyr Scale TQL to filter Test Cases. The param syntax is similar to the JIRA JQL.
+
+          * Available fields: ```projectKey```.
+          * Available operators: ```=```, ```IN```
+
+          Usage examples:
+          * testCase.projectKey = 'JQA'
+          * testCase.projectKey IN ('JQA', 'JQB')
+        example: testCase.projectKey = 'JQA'
+        type: string
+        required: true
+    securedBy: [oauth, basic]
+    responses:
+        200:
+          description: The Cucumber Feature Files were successfully retrieved.
+          body:
+            multipart/form-data:
+              example: !include automation_testcases_get.example
+        204:
+          description: No Test Cases found for the query.
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+
+/project:
+  post:
+    description: |
+      Create a Zephyr Scale project for an existing Jira project. If the Zephyr Scale project exists, enable/disable it
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: project
+        example: !include project_post.example
+    responses:
+        201:
+          description: The Zephyr Scale Project was successfully created.
+          body:
+            application/json:
+              example: !include project_post_response.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include project_response_invalidproject.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+
+/customfield:
+  post:
+    description: |
+      Creates a new custom field for test cases, test plans, test runs, test result or folder.
+      The custom fied name must be unique by project and category.
+
+      Custom fields must have one of these categories:
+      `TEST_PLAN`, `TEST_RUN`, `TEST_STEP`, `TEST_EXECUTION`, `TEST_CASE` or `FOLDER`.
+
+      Custom fields must have of these types: `SINGLE_LINE_TEXT`, `MULTI_LINE_TEXT`, `NUMBER`, `DATE`, `SINGLE_CHOICE_SELECT_LIST`,
+      `CHECKBOX`, `DECIMAL`, `MULTI_CHOICE_SELECT_LIST` or `USER_LIST`.
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: customfield
+        example: !include customfield_post.example
+    responses:
+        201:
+          description: The custom field was successfully created.
+          body:
+            application/json:
+              example: !include customfield_post_response.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include customfield_response_duplicatedname.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+
+/customfield/{customFieldId}/option:
+  post:
+    description: |
+      Creates a new custom field option for `SINGLE_CHOICE_SELECT_LIST` or `MULTI_CHOICE_SELECT_LIST` custom field.
+    securedBy: [oauth, basic]
+    body:
+      application/json:
+        schema: customfieldoption
+        example: !include customfieldoption_post.example
+    responses:
+        201:
+          description: The custom field option was successfully created.
+          body:
+            application/json:
+              example: !include customfieldoption_post_response.example
+        400:
+          description: Some parameters are invalid or not found.
+          body:
+            application/json:
+              example: !include customfieldoption_response_notsupported.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+
+/delete/executiondeletion:
+    post:
+      description: |
+        Starts the deletion process of Test Executions (also known as Test Results). This process only removes executions older than 3 months and it will keep the last test executions.
+        Only Jira Admin users can execute this process.
+      securedBy: [ oauth, basic ]
+      body:
+        application/json:
+          schema: executiondeletion
+          example: !include executiondeletion.example
+      responses:
+        200:
+          description: The deletion process has started.
+          body:
+            application/json:
+              example: !include executiondeletion_post_response.example
+        400:
+          description: Some parameters are invalid (For example&#58; You cannot delete executions created in the last 3 months)
+          body:
+            application/json:
+              example: !include executiondeletion_response_invalid_date.example
+        401:
+          description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+          body:
+            application/json:
+              example: !include response_autherror.example
+
+/delete/executiondeletion/status:
+   get:
+     description: |
+       Gets the status of the test execution deletion process. The statuses can be: IN_PROGRESS, FINISHED or FAILED.
+     securedBy: [ oauth, basic ]
+     responses:
+       200:
+         description: The Status of the deletion process was successfully retrieved.
+         body:
+           application/json:
+             example: !include executiondeletion_status_get_response.example
+       401:
+         description: Authentication error. See the [JIRA REST API](http://docs.atlassian.com/jira/REST/latest) docs for details.
+         body:
+           application/json:
+             example: !include response_autherror.example

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1,0 +1,64 @@
+var expect = require('chai').expect,
+  Converter = require('../../index.js'),
+  fs = require('fs'),
+  VALID_RAML_DIR_PATH = './test/fixtures/valid-raml';
+
+describe('CONVERT FUNCTION TESTS ', function() {
+  describe('The converter should convert the input with different types', function() {
+    it('(type: string)', function (done) {
+      var data = fs.readFileSync(VALID_RAML_DIR_PATH + '/api.raml').toString(),
+        input = {
+          data: data,
+          type: 'string'
+        };
+
+      Converter.convert(input, {}, function(err, result) {
+        expect(err).to.be.null;
+        expect(result.result).to.equal(true);
+        expect(result.output[0].type).to.equal('collection');
+        expect(result.output[0].data).to.have.property('requests');
+        expect(result.output[0].data.requests).to.have.lengthOf(4);
+        done();
+      });
+    });
+
+    it('(type: file)', function (done) {
+      var input = {
+        data: VALID_RAML_DIR_PATH + '/api.raml',
+        type: 'file'
+      };
+
+      Converter.convert(input, {}, function(err, result) {
+        expect(err).to.be.null;
+        expect(result.result).to.equal(true);
+        expect(result.output[0].type).to.equal('collection');
+        expect(result.output[0].data).to.have.property('requests');
+        expect(result.output[0].data.requests).to.have.lengthOf(4);
+        done();
+      });
+    });
+  });
+
+  it('The converter should convert raml spec to postman collection ' +
+      'with remote references present', function(done) {
+    Converter.convert({
+      type: 'file',
+      data: VALID_RAML_DIR_PATH + '/remoteRefs.raml'
+    }, {}, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(2);
+      expect(conversionResult.output[0].type).to.equal('collection');
+      expect(conversionResult.output[1].type).to.equal('environment');
+
+      collectionJSON = conversionResult.output[0].data;
+      expect(collectionJSON).to.be.an('object');
+      expect(collectionJSON).to.have.property('requests');
+      expect(collectionJSON.requests).to.have.lengthOf(46);
+      expect(collectionJSON.requests[0].name).to.eql('/testcase');
+      expect(collectionJSON.requests[0].method).to.eql('post');
+      expect(collectionJSON.requests[0].rawModeData).to.eql('Could not resolve "testcase_post.example"');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/postmanlabs/postman-app-support/issues/11604

### Overview / RCA:

When RAML 0.8 definition has multiple remote references, the current RAML 0.8 parser that’s used to parse RAML 0.8 files throws an error if such remote refs are not resolved.

### Fix:

As the parser itself will throw an error in the case when remote references are present, we’ll be replacing occurrences of all remote references which can be done as following by usage of !include statement.

```
testresult: !include testresult.schema
```

To replace such statements we’ll be using regexp and resolve such references as following.

```
Could not resolve "testresult.schema"
```

### Additional changes:
With this PR, we've also added support for unit tests and GitHub actions that can run them.